### PR TITLE
Define wrap file for ArduinoCore-avr 1.8.2

### DIFF
--- a/libraries/EEPROM/meson.build
+++ b/libraries/EEPROM/meson.build
@@ -1,0 +1,11 @@
+eeprom_inc = [
+  'src/',
+  ]
+
+arduinocore_eeprom_dep = declare_dependency(
+  include_directories : include_directories(eeprom_inc),
+  )
+
+if do_install
+  install_headers(['src/EEPROM.h'], install_dir: 'lib/avr/include/arduino/EEPROM')
+endif

--- a/libraries/HID/meson.build
+++ b/libraries/HID/meson.build
@@ -1,0 +1,20 @@
+hid_src = files([
+  'src/HID.cpp',
+  ])
+
+hid_inc = [
+  'src/',
+  ]
+
+arduinocore_hid_lib = static_library('arduinocore-hid-' + cross_variant, hid_src,
+  include_directories : include_directories(hid_inc),
+  dependencies: [arduinocore_dep],
+  install : do_install,
+  install_dir: 'lib/avr/lib')
+arduinocore_hid_dep = declare_dependency(link_with: arduinocore_hid_lib,
+  include_directories : include_directories(hid_inc),
+  dependencies: [arduinocore_dep])
+
+if do_install
+  install_headers(['src/HID.h'], install_dir: 'lib/avr/include/arduino/HID')
+endif

--- a/libraries/SPI/meson.build
+++ b/libraries/SPI/meson.build
@@ -1,0 +1,20 @@
+spi_src = files([
+  'src/SPI.cpp',
+  ])
+
+spi_inc = [
+  'src/',
+  ]
+
+arduinocore_spi_lib = static_library('arduinocore-spi-' + cross_variant, spi_src,
+  include_directories : include_directories(spi_inc),
+  dependencies: [arduinocore_dep],
+  install : do_install,
+  install_dir: 'lib/avr/lib')
+arduinocore_spi_dep = declare_dependency(link_with: arduinocore_spi_lib,
+  include_directories : include_directories(spi_inc),
+  dependencies: [arduinocore_dep])
+
+if do_install
+  install_headers(['src/SPI.h'], install_dir: 'lib/avr/include/arduino/SPI')
+endif

--- a/libraries/SoftwareSerial/meson.build
+++ b/libraries/SoftwareSerial/meson.build
@@ -1,0 +1,20 @@
+softwareserial_src = files([
+  'src/SoftwareSerial.cpp',
+  ])
+
+softwareserial_inc = [
+  'src/',
+  ]
+
+arduinocore_softwareserial_lib = static_library('arduinocore-softwareserial-' + cross_variant, softwareserial_src,
+  include_directories : include_directories(softwareserial_inc),
+  dependencies: [arduinocore_dep],
+  install : do_install,
+  install_dir: 'lib/avr/lib')
+arduinocore_softwareserial_dep = declare_dependency(link_with: arduinocore_softwareserial_lib,
+  include_directories : include_directories(softwareserial_inc),
+  dependencies: [arduinocore_dep])
+
+if do_install
+  install_headers(['src/SoftwareSerial.h'], install_dir: 'lib/avr/include/arduino/SoftwareSerial')
+endif

--- a/libraries/Wire/meson.build
+++ b/libraries/Wire/meson.build
@@ -1,0 +1,21 @@
+wire_src = files([
+  'src/Wire.cpp',
+  'src/utility/twi.c',
+  ])
+
+wire_inc = [
+  'src/',
+  ]
+
+arduinocore_wire_lib = static_library('arduinocore-wire-' + cross_variant, wire_src,
+  include_directories : include_directories(wire_inc),
+  dependencies: [arduinocore_dep],
+  install : do_install,
+  install_dir: 'lib/avr/lib')
+arduinocore_wire_dep = declare_dependency(link_with: arduinocore_wire_lib,
+  include_directories : include_directories(wire_inc),
+  dependencies: [arduinocore_dep])
+
+if do_install
+  install_headers(['src/Wire.h'], install_dir: 'lib/avr/include/arduino/Wire')
+endif

--- a/libraries/meson.build
+++ b/libraries/meson.build
@@ -1,0 +1,5 @@
+subdir('EEPROM/')
+subdir('HID/')
+subdir('SoftwareSerial/')
+subdir('SPI/')
+subdir('Wire/')

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,8 @@ arduinocore_main_src = files([
 
 
 includes = include_directories([arduinocore_inc])
+
+# Dependencies will use this include_directories to suppress warnings in the Arduino headers
 includes_sys = include_directories([arduinocore_inc], is_system: true)
 
 arduinocore_lib = static_library('arduinocore-' + cross_variant, arduinocore_src, include_directories : [includes],

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libarduinocore-avr', 'c', 'cpp',
-  version : '1.6.20',
+  version : '1.8.2',
   license : 'LGPL2.1+',
   default_options : ['buildtype=minsize',
                      'b_lto=true',
@@ -92,6 +92,7 @@ if do_install
     'cores/arduino/Server.h',
     'cores/arduino/Stream.h',
     'cores/arduino/USBAPI.h',
+    'cores/arduino/USBCore.h',
     'cores/arduino/USBDesc.h',
     'cores/arduino/Udp.h',
     'cores/arduino/WCharacter.h',
@@ -99,7 +100,6 @@ if do_install
     'cores/arduino/binary.h',
     'cores/arduino/new.h',
     'cores/arduino/wiring_private.h',
-    'cores/arduino/USBCore.h'
     ])
   install_headers(arduinocore_header, install_dir: 'lib/avr/include/arduino')
   install_headers(['variants/' + cross_variant + '/pins_arduino.h'], install_dir : 'lib/avr/include/arduino/variants/' + cross_variant)

--- a/meson.build
+++ b/meson.build
@@ -66,14 +66,18 @@ includes_sys = include_directories([arduinocore_inc], is_system: true)
 
 arduinocore_lib = static_library('arduinocore-' + cross_variant, arduinocore_src, include_directories : [includes],
   install : do_install,
-  install_dir : 'lib/avr/lib')
+  install_dir : 'lib/avr/lib',
+  # Only build in a subproject if the dependency is used
+  build_by_default: meson.is_subproject() == false)
 arduinocore_dep = declare_dependency(
   include_directories : [includes_sys],
   link_with : arduinocore_lib)
 
 arduinocore_main_lib = static_library('arduinocore-main-' + cross_variant, arduinocore_main_src, include_directories : [includes],
   install : do_install,
-  install_dir : 'lib/avr/lib')
+  install_dir : 'lib/avr/lib',
+  # Only build in a subproject if the dependency is used
+  build_by_default: meson.is_subproject() == false)
 arduinocore_main_dep = declare_dependency(
   link_with : arduinocore_main_lib,
   dependencies : [arduinocore_dep])

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,107 @@
+project('libarduinocore-avr', 'c', 'cpp',
+  version : '1.6.20',
+  license : 'LGPL2.1+',
+  default_options : ['buildtype=minsize',
+                     'b_lto=true',
+                     'c_std=gnu11',
+                     'cpp_std=gnu++11',
+                     'b_staticpic=false',
+                     ],
+  )
+assert(meson.is_cross_build(), 'Arduino projects can only be built in a cross build environment.')
+# variant has to be defined in a cross file depending on your board
+# It must be set to one of the following values:
+#   circuitplay32u4
+#   eightanaloginputs
+#   ethernet
+#   gemma
+#   leonardo
+#   mega
+#   micro
+#   robot_control
+#   robot_motor
+#   standard
+#   yun
+cross_variant = meson.get_cross_property('variant')
+# whether install definitions are added (not when compiling as subproject)
+do_install = not meson.is_subproject()
+
+
+arduinocore_src = files([
+  'cores/arduino/abi.cpp',
+  'cores/arduino/CDC.cpp',
+  'cores/arduino/HardwareSerial0.cpp',
+  'cores/arduino/HardwareSerial1.cpp',
+  'cores/arduino/HardwareSerial2.cpp',
+  'cores/arduino/HardwareSerial3.cpp',
+  'cores/arduino/HardwareSerial.cpp',
+  'cores/arduino/hooks.c',
+  'cores/arduino/IPAddress.cpp',
+  'cores/arduino/new.cpp',
+  'cores/arduino/PluggableUSB.cpp',
+  'cores/arduino/Print.cpp',
+  'cores/arduino/Stream.cpp',
+  'cores/arduino/Tone.cpp',
+  'cores/arduino/USBCore.cpp',
+  'cores/arduino/WInterrupts.c',
+  'cores/arduino/wiring_analog.c',
+  'cores/arduino/wiring.c',
+  'cores/arduino/wiring_digital.c',
+  'cores/arduino/wiring_pulse.c',
+  'cores/arduino/wiring_shift.c',
+  'cores/arduino/WMath.cpp',
+  'cores/arduino/WString.cpp'
+  ])
+arduinocore_inc = ['cores/arduino', 'variants/' + cross_variant]
+
+arduinocore_main_src = files([
+  'cores/arduino/main.cpp'
+  ])
+
+
+includes = include_directories([arduinocore_inc])
+
+arduinocore_lib = static_library('arduinocore-' + cross_variant, arduinocore_src, include_directories : [includes],
+  install : do_install,
+  install_dir : 'lib/avr/lib')
+arduinocore_dep = declare_dependency(
+  include_directories : [includes],
+  link_with : arduinocore_lib)
+
+arduinocore_main_lib = static_library('arduinocore-main-' + cross_variant, arduinocore_main_src, include_directories : [includes],
+  install : do_install,
+  install_dir : 'lib/avr/lib')
+arduinocore_main_dep = declare_dependency(
+  link_with : arduinocore_main_lib,
+  dependencies : [arduinocore_dep])
+
+
+subdir('libraries/')
+
+
+if do_install
+  arduinocore_header = files([
+    'cores/arduino/Arduino.h',
+    'cores/arduino/Client.h',
+    'cores/arduino/HardwareSerial.h',
+    'cores/arduino/HardwareSerial_private.h',
+    'cores/arduino/IPAddress.h',
+    'cores/arduino/PluggableUSB.h',
+    'cores/arduino/Print.h',
+    'cores/arduino/Printable.h',
+    'cores/arduino/Server.h',
+    'cores/arduino/Stream.h',
+    'cores/arduino/USBAPI.h',
+    'cores/arduino/USBDesc.h',
+    'cores/arduino/Udp.h',
+    'cores/arduino/WCharacter.h',
+    'cores/arduino/WString.h',
+    'cores/arduino/binary.h',
+    'cores/arduino/new.h',
+    'cores/arduino/wiring_private.h',
+    'cores/arduino/USBCore.h'
+    ])
+  install_headers(arduinocore_header, install_dir: 'lib/avr/include/arduino')
+  install_headers(['variants/' + cross_variant + '/pins_arduino.h'], install_dir : 'lib/avr/include/arduino/variants/' + cross_variant)
+endif
+

--- a/meson.build
+++ b/meson.build
@@ -60,12 +60,13 @@ arduinocore_main_src = files([
 
 
 includes = include_directories([arduinocore_inc])
+includes_sys = include_directories([arduinocore_inc], is_system: true)
 
 arduinocore_lib = static_library('arduinocore-' + cross_variant, arduinocore_src, include_directories : [includes],
   install : do_install,
   install_dir : 'lib/avr/lib')
 arduinocore_dep = declare_dependency(
-  include_directories : [includes],
+  include_directories : [includes_sys],
   link_with : arduinocore_lib)
 
 arduinocore_main_lib = static_library('arduinocore-main-' + cross_variant, arduinocore_main_src, include_directories : [includes],

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
 directory = avr
 
-source_url = http://downloads.arduino.cc/cores/avr-1.6.20.tar.bz2
-source_filename = avr-1.6.20.tar.bz2
-source_hash = 61f3d59a2ab2e9191230e91e79ee91c05f32b32c33129d34d76ef87e56d257e1
+source_url = http://downloads.arduino.cc/cores/avr-1.8.2.tar.bz2
+source_filename = avr-1.8.2.tar.bz2
+source_hash = 6213d41c6e91a75ac931527da5b10f2dbe0140c8cc1dd41b06cd4e78b943f41b

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = avr
+
+source_url = http://downloads.arduino.cc/cores/avr-1.6.20.tar.bz2
+source_filename = avr-1.6.20.tar.bz2
+source_hash = 61f3d59a2ab2e9191230e91e79ee91c05f32b32c33129d34d76ef87e56d257e1


### PR DESCRIPTION
NOTE: I can't seem to indicate that this should be merged into a new branch in the pull request, so I've currently set it to `master`.

This updates the version number and wrap file definition for ArduinoCore-avr 1.8.2., which is the latest release.

@jpakkane  @tommie-lie